### PR TITLE
fix width text title of CategoryItem

### DIFF
--- a/app/src/main/java/com/example/tudeeapp/presentation/common/components/CategoryItem.kt
+++ b/app/src/main/java/com/example/tudeeapp/presentation/common/components/CategoryItem.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
@@ -21,6 +22,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.tudeeapp.R
@@ -41,7 +43,7 @@ fun CategoryItem(
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
+        modifier = modifier.width(104.dp)
     ) {
         Box(
             modifier = Modifier
@@ -88,7 +90,9 @@ fun CategoryItem(
         Text(
             text = label,
             style = Theme.textStyle.label.small,
-            color = Theme.colors.text.body
+            color = Theme.colors.text.body,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/app/src/main/java/com/example/tudeeapp/presentation/screen/categories/CategoriesScreen.kt
+++ b/app/src/main/java/com/example/tudeeapp/presentation/screen/categories/CategoriesScreen.kt
@@ -95,6 +95,7 @@ fun CategoriesContent(
                     LazyVerticalGrid(
                         columns = GridCells.Adaptive(104.dp),
                         verticalArrangement = Arrangement.spacedBy(24.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                         modifier = Modifier
                             .fillMaxSize()
                             .background(Theme.colors.surfaceColors.surface),


### PR DESCRIPTION

![bug 1](https://github.com/user-attachments/assets/ffa064da-f929-432c-9a22-b8189ed13bee)
![bug2](https://github.com/user-attachments/assets/b5a6ad81-46a7-4807-a90b-076a8a69c241)
![fix bug1](https://github.com/user-attachments/assets/086456ec-f17f-4466-84c4-7b480d411898)
![fix bug2](https://github.com/user-attachments/assets/b9b6f294-64b7-457e-8fd5-7b3ceb5aed63)
constrain CategoryItem label text to item width and Apply maxLines = 1 and TextOverflow.Ellipsis to the label Text to prevent overflow beyond the item width