### PR TITLE
refactor: Update dark mode logic to support system theme

### DIFF
--- a/app/src/main/java/com/example/tudeeapp/data/source/local/sharedPreferences/AppPreferences.kt
+++ b/app/src/main/java/com/example/tudeeapp/data/source/local/sharedPreferences/AppPreferences.kt
@@ -16,10 +16,10 @@ class AppPreferences(context: Context) {
         prefs.edit { putBoolean(KEY_ONBOARDING_COMPLETED, completed) }
     }
 
-    fun isDarkTheme(): Boolean = prefs.getBoolean(KEY_DARK_THEME, false)
+    fun isDarkTheme(): Int = prefs.getInt(KEY_DARK_THEME, 2)
 
     fun setDarkTheme(isDark: Boolean) {
-        prefs.edit { putBoolean(KEY_DARK_THEME, isDark) }
+        prefs.edit { putInt(KEY_DARK_THEME, if (isDark) 1 else 0) }
     }
 
     companion object {

--- a/app/src/main/java/com/example/tudeeapp/presentation/TudeeAppScaffold.kt
+++ b/app/src/main/java/com/example/tudeeapp/presentation/TudeeAppScaffold.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -43,8 +44,19 @@ fun TudeeAppScaffold() {
     val snackBarState = remember { SnackBarState() }
     val context = LocalContext.current
     val appPrefs = remember { AppPreferences(context) }
+
+    val isSystemInDarkTheme = isSystemInDarkTheme()
+
     val themeMode = rememberSaveable {
-        mutableStateOf(if (appPrefs.isDarkTheme()) TudeeThemeMode.DARK else TudeeThemeMode.LIGHT)
+        val isDarkTheme = appPrefs.isDarkTheme()
+        val currentTheme = if (isDarkTheme == 1) {
+            TudeeThemeMode.DARK
+        } else if (isDarkTheme == 0) {
+            TudeeThemeMode.LIGHT
+        } else {
+            if (isSystemInDarkTheme) TudeeThemeMode.DARK else TudeeThemeMode.LIGHT
+        }
+        mutableStateOf(currentTheme)
     }
 
     val view = LocalView.current
@@ -52,7 +64,14 @@ fun TudeeAppScaffold() {
 
     LaunchedEffect(themeMode.value) {
         val darkIcons = themeMode.value == TudeeThemeMode.LIGHT
-        themeMode.value = if (appPrefs.isDarkTheme()) TudeeThemeMode.DARK else TudeeThemeMode.LIGHT
+        val isDarkTheme = appPrefs.isDarkTheme()
+        themeMode.value = if (isDarkTheme == 1) {
+            TudeeThemeMode.DARK
+        } else if (isDarkTheme == 0) {
+            TudeeThemeMode.LIGHT
+        } else {
+            if (isSystemInDarkTheme) TudeeThemeMode.DARK else TudeeThemeMode.LIGHT
+        }
 
         activity?.window?.also { window ->
             WindowInsetsControllerCompat(window, view).apply {

--- a/app/src/main/java/com/example/tudeeapp/presentation/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/tudeeapp/presentation/screen/home/HomeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -55,9 +56,10 @@ fun HomeScreen(homeViewModel: HomeViewModel = koinViewModel()) {
     LaunchedEffect(Unit) {
         homeViewModel.getTasks()
     }
-
+    val isSystemInDarkTheme = isSystemInDarkTheme()
     HomeScreenContent(
         state = state,
+        isSystemInDarkTheme = isSystemInDarkTheme,
         onToggleTheme = { isDark -> homeViewModel.onToggledAction(isDark, themeMode) },
         onFloatingActionButtonClick = homeViewModel::onFloatingActionButtonClick,
         onTasksCountClick = homeViewModel::onTasksCountClick,
@@ -68,6 +70,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = koinViewModel()) {
 @Composable
 fun HomeScreenContent(
     state: HomeUiState,
+    isSystemInDarkTheme: Boolean,
     onToggleTheme: (Boolean) -> Unit,
     onFloatingActionButtonClick: () -> Unit,
     onTasksCountClick: (String) -> Unit,
@@ -79,7 +82,11 @@ fun HomeScreenContent(
                 modifier = Modifier
                     .background(Theme.colors.primary)
                     .statusBarsPadding(),
-                isDarkMode = state.isDarkMode,
+                isDarkMode = if (state.isDarkMode == 2) {
+                    isSystemInDarkTheme
+                } else {
+                    state.isDarkMode == 1
+                },
                 onToggleTheme = onToggleTheme,
             )
         },

--- a/app/src/main/java/com/example/tudeeapp/presentation/screen/home/HomeUiState.kt
+++ b/app/src/main/java/com/example/tudeeapp/presentation/screen/home/HomeUiState.kt
@@ -14,7 +14,7 @@ data class HomeUiState(
     val doneTasks: List<TaskUiState> = emptyList(),
     val isTasksEmpty: Boolean = true,
     val sliderState: SliderUiState = SliderUiState.NothingState,
-    val isDarkMode: Boolean = false,
+    val isDarkMode: Int = 2,
     val isLoading: Boolean = false,
     val isSuccess: Boolean = false,
     val error: String? = null

--- a/app/src/main/java/com/example/tudeeapp/presentation/screen/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/tudeeapp/presentation/screen/home/HomeViewModel.kt
@@ -32,11 +32,14 @@ class HomeViewModel(
         onError = { errorMessage -> _uiState.update { it.copy(error = errorMessage) } }
     )
 
-    fun onToggledAction(isDarkMode: Boolean,themeMode: MutableState<TudeeThemeMode>) = launchSafely(
+    fun onToggledAction(
+        isDarkMode: Boolean,
+        themeMode: MutableState<TudeeThemeMode>,
+    ) = launchSafely(
         onLoading = { _uiState.update { it.copy(isLoading = true) } },
         onSuccess = {
             themeMode.value = if (isDarkMode) TudeeThemeMode.DARK else TudeeThemeMode.LIGHT
-            _uiState.update { it.copy(isLoading = false, isDarkMode = isDarkMode) }
+            _uiState.update { it.copy(isLoading = false, isDarkMode = if (isDarkMode) 1 else 0) }
             appPreferences.setDarkTheme(isDarkMode)
                     },
         onError = { errorMessage -> _uiState.update { it.copy(isLoading = false, error = errorMessage) } }


### PR DESCRIPTION
This commit refactors the dark mode implementation to include support for following the system's theme setting.

The `isDarkMode` state in `HomeUiState` and `AppPreferences` is now an `Int` to represent three states:
- 0: Light mode
- 1: Dark mode
- 2: Follow system theme

The `HomeScreen` and `TudeeAppScaffold` have been updated to correctly interpret this new state and apply the appropriate theme based on the user's preference or the system setting.